### PR TITLE
Data collections for the front-page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,3 +14,8 @@ exclude:
   - Gemfile
   - Gemfile.lock
 future: true
+
+# Custom collections
+collections:
+  scala_items:
+    output: false

--- a/_data/common.yml
+++ b/_data/common.yml
@@ -1,3 +1,3 @@
 # SNS URLs
-githubUrl: http://github.com/scala/scala
-twitter: http://twitter.com/scala_lang
+githubUrl: https://github.com/scala/scala
+twitter: https://twitter.com/scala_lang

--- a/_data/common.yml
+++ b/_data/common.yml
@@ -1,0 +1,3 @@
+# SNS URLs
+githubUrl: http://github.com/scala/scala
+twitter: http://twitter.com/scala_lang

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,0 +1,44 @@
+- title: Documentation
+  links:
+    - title: Getting Started
+      url: /documentation/getting-started/
+    - title: API
+      url: "http://www.scala-lang.org/api/current/index.html?_ga=1.211088853.1310790544.1468501313#package"
+    - title: Overviews/Guides
+      url: "http://docs.scala-lang.org/overviews/?_ga=1.9844085.1310790544.1468501313"
+    - title: Tutorials
+      url: "http://docs.scala-lang.org/overviews/?_ga=1.211088853.1310790544.1468501313"
+    - title: Language Specification
+      url: "http://scala-lang.org/files/archive/spec/2.12/"
+- title: Download
+  links: 
+    - title: Current Version
+      url: "/download/"
+    - title: All versions
+      url: "/download/all/"
+- title: Community
+  links:
+    - title: Community
+      url: "/community/"
+    - title: Mailing Lists
+      url: "/community/index.html#mailing-lists"
+    - title: Chat Rooms & More
+      url: "/community/index.html#chat-rooms"
+    - title: Libraries and Tools
+      url: "/community/index.html#community-libraries-and-tools"
+    - title: "The Scala Center"
+      url: https://scala.epfl.ch/
+- title: Contribute
+  links: 
+    - title: How to help
+      url: "/contribute/"
+    - title: Report an Issue
+      url: "/contribute/bug-reporting-guide/"
+- title: Scala
+  links:
+    - title: Blog
+      url: "/blog/"
+    - title: Code of Conduct
+      url: "/conduct/"
+    - title: License
+      url: "/license/"

--- a/_data/nav-header.yml
+++ b/_data/nav-header.yml
@@ -1,0 +1,10 @@
+- title: Documentation
+  url: /documentation/
+- title: Download
+  url: /download/
+- title: Community
+  url: /community/
+- title: Contribute
+  url: /contribute/
+- title: Blog
+  url: /blog/

--- a/_data/scala-supporters.yml
+++ b/_data/scala-supporters.yml
@@ -1,0 +1,24 @@
+supporters:
+  - logo: /epfl.png
+    url: https://www.epfl.ch
+  - logo: /ibm.png
+    url: http://www.ibm.com
+  - logo: /verizon.png
+    url: http://www.verizon.com
+  - logo: /goldman-sachs.png
+    url: http://www.goldmansachs.com
+  - logo: /nitro.png
+    url: https://www.gonitro.com
+  - logo: /47deg.png
+    url: http://www.47deg.com/
+  - logo: /sap.png
+    url: http://www.sap.com
+  - logo: /tapad.png
+    url: http://www.tapad.com
+  - logo: /your-company.png
+    url: https://scala.epfl.ch/individual-membership.html
+maintainers:
+  - logo: /scala-center.png
+    url: https://scala.epfl.ch/
+  - logo: /lightbend.png
+    url: http://www.lightbend.com/

--- a/_scala_items/1-seamless-java-interop.md
+++ b/_scala_items/1-seamless-java-interop.md
@@ -1,0 +1,62 @@
+---
+shortTitle: "Seamless Java Interop"
+shortDescription: "Scala runs on the JVM, so Java and Scala stacks can be freely mixed for totally seamless integration."
+scastieUrl: 
+---
+
+<div class="java-interop-wrapper" style="width: 500px">
+<figure class="code java-interop1" style="margin-top: 20px;">
+  <figcaption>Author.scala</figcaption>
+  <pre><code>class Author(val firstName: String,
+    val lastName: String) extends Comparable[Author] {
+
+  override def compareTo(that: Author) = {
+    val lastNameComp = this.lastName compareTo that.lastName
+    if (lastNameComp != 0) lastNameComp
+    else this.firstName compareTo that.firstName
+  }
+}
+
+object Author {
+  def loadAuthorsFromFile(file: java.io.File): List[Author] = ???
+}</code></pre>
+</figure>
+<figure class="code java-interop2" style="margin-top: 10px;">
+  <figcaption>App.java</figcaption>
+  <pre><code>import static scala.collection.JavaConversions.asJavaCollection;
+
+public class App {
+    public List&lt;Author&gt; loadAuthorsFromFile(File file) {
+        return new ArrayList&lt;Author&gt;(asJavaCollection(
+            Author.loadAuthorsFromFile(file)));
+    }
+
+    public void sortAuthors(List&lt;Author&gt; authors) {
+        Collections.sort(authors);
+    }
+
+    public void displaySortedAuthors(File file) {
+        List&lt;Author&gt; authors = loadAuthorsFromFile(file);
+        sortAuthors(authors);
+        for (Author author : authors) {
+            System.out.println(
+                author.lastName() + ", " + author.firstName());
+        }
+    }
+}</code></pre>
+</figure>
+</div>
+
+<div class="snippet-explanation" style="width: 370px;">
+<h3>Combine Scala and Java seamlessly</h3>
+<p>Scala classes are ultimately JVM classes. You can create Java objects, call
+their methods and inherit from Java classes transparently from Scala.
+Similarly, Java code can reference Scala classes and objects.</p>
+<p>
+In this example, the Scala class <code>Author</code> implements the Java
+interface <code>Comparable&lt;T&gt;</code> and works with Java
+<code>File</code>s. The Java code uses a method from the companion object
+<code>Author</code>, and accesses fields of the <code>Author</code> class.
+It also uses <code>JavaConversions</code> to convert between Scala collections
+and Java collections.
+</p></div>

--- a/_scala_items/2-type-inference.md
+++ b/_scala_items/2-type-inference.md
@@ -1,0 +1,44 @@
+---
+shortTitle: "Type Inference"
+shortDescription: "So the type system doesn’t feel so static. Don’t work for the type system. Let the type system work for you!"
+scastieUrl: 
+---
+<figure class="code type-inference" style="width: 450px; margin-top: 20px;">
+  <figcaption>Type inference</figcaption>
+  <pre><code>scala> class Person(val name: String, val age: Int) {
+     |   override def toString = s"$name ($age)"
+     | }
+defined class Person
+
+scala> def underagePeopleNames(persons: List[Person]) = {
+     |   for (person &lt;- persons; if person.age &lt; 18)
+     |     yield person.name
+     | }
+underagePeopleNames: (persons: List[Person])List[String]
+
+scala> def createRandomPeople() = {
+     |   val names = List("Alice", "Bob", "Carol",
+     |       "Dave", "Eve", "Frank")
+     |   for (name &lt;- names) yield {
+     |     val age = (Random.nextGaussian()*8 + 20).toInt
+     |     new Person(name, age)
+     |   }
+     | }
+createRandomPeople: ()List[Person]
+
+scala> val people = createRandomPeople()
+people: List[Person] = List(Alice (16), Bob (16), Carol (19), Dave (18), Eve (26), Frank (11))
+
+scala> underagePeopleNames(people)
+res1: List[String] = List(Alice, Bob, Frank)</code></pre>
+</figure>
+<div class="snippet-explanation">
+  <h3>Let the compiler figure out the types for you</h3>
+<p>The Scala compiler is smart about static types. Most of the time, you need
+not tell it the types of your variables. Instead, its powerful type inference
+will figure them out for you.</p>
+<p>
+In this interactive REPL session (Read-Eval-Print-Loop), we define a
+class and two functions. You can observe that the compiler infers the result
+types of the functions automatically, as well as all the intermediate values.
+</p></div>

--- a/_scala_items/3-concurrency-distribution.md
+++ b/_scala_items/3-concurrency-distribution.md
@@ -1,0 +1,25 @@
+---
+shortTitle: "Concurrency & Distribution"
+shortDescription: "Use data-parallel operations on collections, use actors for concurrency and distribution, or futures for asynchronous programming."
+scastieUrl: 
+---
+<figure class="code concurrency" style="width: 450px; margin-top: 20px;">
+  <figcaption>Concurrent/Distributed</figcaption>
+  <pre><code>val x = future { someExpensiveComputation() }
+val y = future { someOtherExpensiveComputation() }
+val z = for (a &lt;- x; b &lt;- y) yield a*b
+for (c &lt;- z) println("Result: " + c)
+println("Meanwhile, the main thread goes on!")</code></pre>
+</figure>
+
+<div class="snippet-explanation">
+  <h3>Go Concurrent or Distributed with Futures &amp; Promises</h3>
+<p>In Scala, futures and promises can be used to process data <i>asynchronously</i>, making it easier to parallelize or even distribute your application.</p>
+<p>
+In this example, the <code>future{}</code> construct evaluates its argument asynchronously, and returns
+a handle to the asynchronous result as a <code>Future[Int]</code>.
+For-comprehensions can be used to register new callbacks (to post new things to do) when the future is
+completed, i.e., when the computation is finished.
+And since all this is executed asynchronously, without blocking, the main
+program thread can continue doing other work in the meantime.
+</p></div>

--- a/_scala_items/4-traits.md
+++ b/_scala_items/4-traits.md
@@ -1,0 +1,46 @@
+---
+shortTitle: "Traits"
+shortDescription: "Combine the flexibility of Java-style interfaces with the power of classes. Think principled multiple-inheritance."
+scastieUrl: 
+---
+{% comment %}
+Borrowed from
+http://gleichmann.wordpress.com/2009/10/21/scala-in-practice-composing-traits-lego-style/
+{% endcomment %}
+
+<figure class="code traits" style="width: 450px;">
+  <figcaption>Traits</figcaption>
+  <pre><code>abstract class Spacecraft {
+  def engage(): Unit
+}
+trait CommandoBridge extends Spacecraft {
+  def engage(): Unit = {
+    for (_ &lt;- 1 to 3)
+      speedUp()
+  }
+  def speedUp(): Unit
+}
+trait PulseEngine extends Spacecraft {
+  val maxPulse: Int
+  var currentPulse: Int = 0
+  def speedUp(): Unit = {
+    if (currentPulse &lt; maxPulse)
+      currentPulse += 1
+  }
+}
+class StarCruiser extends Spacecraft
+                     with CommandoBridge
+                     with PulseEngine {
+  val maxPulse = 200
+}</code></pre>
+</figure>
+
+<div class="snippet-explanation">
+  <h3>Flexibly Combine Interface &amp; Behavior</h3>
+  <p>
+In Scala, <i>multiple traits</i> can be mixed into a class to combine their interface and their
+behavior.</p>
+<p>Here, a <code>StarCruiser</code> is a <code>Spacecraft</code> with a <code>CommandoBridge</code> that knows how to
+engage the ship (provided a means to speed up) and a <code>PulseEngine</code> that
+specifies how to speed up.
+</p></div>

--- a/_scala_items/5-pattern-matching.md
+++ b/_scala_items/5-pattern-matching.md
@@ -1,0 +1,32 @@
+---
+shortTitle: "Pattern Matching"
+shortDescription: "Think “switch” on steroids. Match against class hierarchies, sequences, and more."
+scastieUrl: 
+---
+<figure class="code pattern-matching" style="width: 500px; float: right;">
+  <figcaption>Pattern matching</figcaption>
+  <pre><code>// Define a set of case classes for representing binary trees.
+sealed abstract class Tree
+case class Node(elem: Int, left: Tree, right: Tree) extends Tree
+case object Leaf extends Tree
+
+// Return the in-order traversal sequence of a given tree.
+def inOrder(t: Tree): List[Int] = t match {
+  case Node(e, l, r) => inOrder(l) ::: List(e) ::: inOrder(r)
+  case Leaf          => List()
+}</code></pre>
+</figure>
+
+<div class="snippet-explanation" style="width: 350px;">
+  <h3>Switch on the structure of your data</h3>
+<p>In Scala, <em>case classes</em> are used to represent structural data
+types. They implicitly equip the class with meaningful <code>toString</code>,
+<code>equals</code> and <code>hashCode</code> methods, as well as the
+ability to be deconstructed with <em>pattern matching</em>.</p>
+<p>
+In this example, we define a small set of case classes that represent binary
+trees of integers (the generic version is omitted for simplicity here).
+In <code>inOrder</code>, the <code>match</code> construct chooses the right
+branch, depending on the type of <code>t</code>, and at the same time
+deconstructs the arguments of a <code>Node</code>.
+</p></div>

--- a/_scala_items/6-higher-order-functions.md
+++ b/_scala_items/6-higher-order-functions.md
@@ -1,0 +1,45 @@
+---
+shortTitle: "Higher-order functions"
+shortDescription: "Functions are first-class objects. Compose them with guaranteed type safety. Use them anywhere, pass them to anything."
+scastieUrl: 
+---
+<div class="snippet-explanation" style="width: 100%;">
+  <h3>Go Functional with Higher-Order Functions</h3>
+  <p>In Scala, functions are values, and can be defined as anonymous functions
+  with a concise syntax.</p>
+</div>
+
+<figure class="code" style="width: 445px; float: left;">
+  <figcaption>Scala</figcaption>
+  <pre><code>val people: Array[Person]
+
+// Partition `people` into two arrays `minors` and `adults`.
+// Use the higher-order function `(_.age &lt; 18)` as a predicate for partitioning.
+val (minors, adults) = people partition (_.age &lt; 18)</code></pre>
+</figure>
+<figure class="code" style="width: 445px; float: right;">
+  <figcaption>Java</figcaption>
+  <pre><code>List&lt;Person&gt; people;
+
+List&lt;Person&gt; minors = new ArrayList&lt;Person&gt;(people.size());
+List&lt;Person&gt; adults = new ArrayList&lt;Person&gt;(people.size());
+for (Person person : people) {
+    if (person.getAge() &lt; 18)
+        minors.add(person);
+    else
+        adults.add(person);
+}</code></pre>
+</figure>
+
+<div class="snippet-explanation" style="width: 100%;">
+  <p>
+    In the Scala example on the left, the <code>partition</code> method, available on all
+    collection types (including <code>Array</code>), returns two new collections
+    of the same type. Elements from the original collection are partitioned
+    according to a predicate, which is given as a lambda, i.e., an anonymous
+    function. The <code>_</code> stands for the parameter to the lambda, i.e.,
+    the element that is being tested. This particular lambda can also be written
+    as <code>(x => x.age &lt; 18)</code>.
+  </p>
+  <p>The same program is implemented in Java on the right.</p>
+</div>

--- a/index.md
+++ b/index.md
@@ -1,4 +1,68 @@
 ---
 layout: frontpage
+
+# Links of the Download / API Docs sections
+gettingStarted:
+  - title: "Getting Started"
+    links:
+      - title: "Milestones, nightlies, etc."
+        url: "/download/"
+      - title: "All Previous Releases"
+        url: "/download/all/"
+apiDocs:
+  - title: "Current API Docs"
+    links:
+      - title: "API Docs (other versions)"
+        url: "/documentation/api/"
+      - title: "Scala Documentation"
+        url: "/documentation/"
+      - title: "Language Specification"
+        url: "http://scala-lang.org/files/archive/spec/2.12/"
+
+# Scala IDEs
+scalaIDEs:
+  - name: IntelliJ
+    icon: /resources/img/IDEs/intellij.png
+    ensime: false
+  - name: Sublime Text
+    icon: /resources/img/IDEs/sublime.png
+    ensime: true
+  - name: Atom
+    icon: /resources/img/IDEs/atom.png
+    ensime: true
+  - name: Eclipse
+    icon: /resources/img/IDEs/eclipse.png
+    ensime: false
+  - name: Ensime
+    icon: /resources/img/IDEs/ensime.png
+    ensime: false
+
+# Gitter channels
+gitterChannels:
+  - name: scala
+    url: https://gitter.im/scala/scala
+  - name: center
+    url: https://gitter.im/scala/center
+  - name: contributors
+    url: https://gitter.im/scala/contributors
+  - name: pickling
+    url: https://gitter.im/scala/pickling
+  - name: scala-parser-combinator
+    url: https://gitter.im/scala/scala-parser-combinator
+  - name: collection-strawman
+    url: https://gitter.im/scala/collection-strawman
+  - name: scala-xml
+    url: https://gitter.im/scala/scala-xml
+  - name: scala-india
+    url: https://gitter.im/scala/scala-india
+  - name: community-builds
+    url: https://gitter.im/scala/community-builds
+
+# Communities
+communities:
+  - icon: /resources/img/communities/typelevel.png
+    url: http://typelevel.org/
+  - icon: /resources/img/communities/scalabridge.png
+    url: http://www.scalabridge.org/
 ---
 


### PR DESCRIPTION
Fixes #13 

This PR adds data collections for the new features to be added to the front page of the Scala Lang website. These are divided in different set of data for increased readabily and make it easier for contributors to update them:

- Fixed elements to be used in the front-page are specified as variables inside its markdown file (index.md). i.e.: scala IDEs, communities, gitter channels...
- Elements more subject to be changed are moved to YAML data files. i.e.: footer links, scala supporter/maintainer organizations...
- More complex and subject to change data elements are moved to custom collections. In this case, I've moved the main examples from the front page (previously hardcoded in partial layouts) to an specific collection.

Could you please review, @vejeta @dominv? Thanks!!